### PR TITLE
extended the core decentralized cloud storage smart contract with a full suite of file lifecycle management and access control mechanisms

### DIFF
--- a/contracts/sBTC-CloudChainFS.clar
+++ b/contracts/sBTC-CloudChainFS.clar
@@ -97,3 +97,90 @@
     (ok true)
   )
 )
+
+
+ (define-public (delete-file (file-id uint))
+   (let
+     (
+       (file (unwrap! (map-get? files { file-id: file-id }) err-not-found))
+     )
+     (asserts! (file-exists file-id) err-not-found)
+     (asserts! (is-eq (get owner file) tx-sender) err-unauthorized)
+     (map-delete files { file-id: file-id })
+     (ok true)
+   )
+ )
+
+ (define-public (transfer-file-ownership (file-id uint) (new-owner principal))
+   (let
+     (
+       (file (unwrap! (map-get? files { file-id: file-id }) err-not-found))
+     )
+     (asserts! (file-exists file-id) err-not-found)
+     (asserts! (is-eq (get owner file) tx-sender) err-unauthorized)
+     (map-set files
+       { file-id: file-id }
+       (merge file { owner: new-owner })
+     )
+     (ok true)
+   )
+ )
+
+ (define-public (grant-permission (file-id uint) (permission bool) (recipient principal))
+   (let
+     (
+       (file (unwrap! (map-get? files { file-id: file-id }) err-not-found))
+     )
+     ;; Check if file-id is valid (greater than 0 and less than or equal to total-files)
+     (asserts! (and (> file-id u0) (<= file-id (var-get total-files))) err-not-found)
+
+     ;; Ensure the caller is the file's owner
+     (asserts! (is-eq (get owner file) tx-sender) err-unauthorized)
+
+     ;; Ensure the recipient is not the same as the owner
+     (asserts! (not (is-eq recipient (get owner file))) err-invalid-recipient)
+
+     ;; Update the file's permissions
+     (map-set file-permissions
+       { file-id: file-id, user: recipient }
+       { permission: permission }
+     )
+
+     ;; Return success
+     (ok true)
+   )
+ )
+
+ (define-public (revoke-permission (file-id uint) (user principal))
+   (let
+     (
+       (file (unwrap! (map-get? files { file-id: file-id }) err-not-found))
+     )
+     ;; Check if file-id is valid
+     (asserts! (and (> file-id u0) (<= file-id (var-get total-files))) err-not-found)
+
+     ;; Ensure the caller is the file's owner
+     (asserts! (is-eq (get owner file) tx-sender) err-unauthorized)
+
+     ;; Ensure the user is not the same as the owner
+     (asserts! (not (is-eq user (get owner file))) err-invalid-recipient)
+
+     ;; Remove the permission
+     (map-delete file-permissions { file-id: file-id, user: user })
+
+     ;; Return success
+     (ok true)
+   )
+ )
+
+ ;; read-only functions
+ (define-read-only (get-total-files)
+   (ok (var-get total-files))
+ )
+
+ (define-read-only (get-file-info (file-id uint))
+   (match (map-get? files { file-id: file-id })
+     file-info (ok file-info)
+     err-not-found
+   )
+ )


### PR DESCRIPTION

##  Pull Request: Ownership, Permissions, and File Management Enhancements for Decentralized Cloud Storage

### 🧾 Summary

This PR extends the core decentralized cloud storage smart contract with a full suite of **file lifecycle management** and **access control mechanisms**, including:

* File deletion
* Ownership transfers
* Granting/revoking access permissions
* Read-only metadata access

These additions support **collaborative file usage**, **ownership migration**, and **fine-grained access control** — critical for real-world decentralized storage systems.

---

### ✅ New Features

#### 🗑️ `delete-file (file-id)`

Allows the file owner to permanently delete a file from the storage registry.

* ✔ Checks if file exists
* ✔ Ensures caller is the file owner
* 🧹 Removes file metadata from `files` map

```clojure
(delete-file u1)
;; Returns: (ok true)
```

---

#### 🔄 `transfer-file-ownership (file-id, new-owner)`

Transfers ownership of a file to another principal.

* ✔ Verifies file exists and caller is the current owner
* ✔ Updates the `owner` field in the file's metadata

```clojure
(transfer-file-ownership u1 'SPXYZ...)
;; Returns: (ok true)
```

---

#### 🔐 `grant-permission (file-id, permission, recipient)`

Grants or revokes access to a specific user for a file.

* ✔ Must be invoked by the file owner
* ✔ Cannot grant permissions to self
* ✔ Updates `file-permissions` map for the recipient

```clojure
(grant-permission u1 true 'SPABC...)
;; Returns: (ok true)
```

---

#### 🚫 `revoke-permission (file-id, user)`

Revokes access permission from a user.

* ✔ Validates that caller is the file owner
* ✔ Deletes recipient entry from `file-permissions` map

```clojure
(revoke-permission u1 'SPABC...)
;; Returns: (ok true)
```

---

### 🧩 Read-Only Functions

#### 📊 `get-total-files`

Returns the number of files uploaded on-chain.

```clojure
(get-total-files)
;; Returns: (ok uX)
```

#### 📄 `get-file-info (file-id)`

Returns metadata for a file if it exists.

* 📝 Includes: owner, name, size, created-at
* ❌ Returns `err-not-found` if file does not exist

```clojure
(get-file-info u1)
;; Returns: (ok { owner: ..., name: ..., size: ..., created-at: ... })
```

---

### 🛡️ Validations & Safeguards

* ✅ All state-changing functions include `unwrap!` and `asserts!` to guard against:

  * Invalid file IDs
  * Unauthorized access
  * Invalid recipients
* ✅ File ID boundaries are enforced (e.g. `file-id > 0 && <= total-files`).
* ✅ Principals cannot modify files or permissions unless they are the owner.

---

### 📌 Testing Notes

* Confirmed:

  * Owner can delete and transfer files
  * Non-owners are denied permission to modify or delete
  * Permissions are correctly added and removed from the `file-permissions` map
* Edge cases handled:

  * Invalid file ID
  * Granting permissions to self
  * Revoking from non-existent users

---
